### PR TITLE
Improve Heap Allocation

### DIFF
--- a/src/drivers/keyboard/scancode_handler.c
+++ b/src/drivers/keyboard/scancode_handler.c
@@ -193,7 +193,8 @@ static const unsigned char KEYBOARD_ASCII_MAPH_OTHERS[] = {
     KEYBOARD_SC_RPF0_keypad_minus, '-',
     KEYBOARD_SC_RPF0_keypad_mul, '*',
     KEYBOARD_SC_RPF0_keypad_plus, '+',
-    KEYBOARD_SC_PE0_RPF0_keypad_enter, '\n'
+    KEYBOARD_SC_PE0_RPF0_keypad_enter, '\n',
+    KEYBOARD_SC_RPF0_backspace, '\b'
 };
 
 static unsigned char KEYBOARD_ASCII_MAPPING[256];

--- a/src/usr/include/stddef.h
+++ b/src/usr/include/stddef.h
@@ -9,6 +9,10 @@ namespace std {
 #define NULL 0
 #endif
 
+typedef char  int8_t;
+typedef short int16_t;
+typedef int   int32_t;
+
 typedef unsigned char  uint8_t;
 typedef unsigned short uint16_t;
 typedef unsigned int   uint32_t;

--- a/src/usr/include/stdlib.h
+++ b/src/usr/include/stdlib.h
@@ -19,6 +19,7 @@ int max(int, int);
 int abs(int a);
 
 int benchmark_get_heap_usage();
+int benchmark_get_heap_area();
 void* malloc(size_t size);
 void free(void* ptr);
 

--- a/src/usr/include/stdlib.h
+++ b/src/usr/include/stdlib.h
@@ -18,6 +18,7 @@ int min(int, int);
 int max(int, int);
 int abs(int a);
 
+int benchmark_get_heap_usage();
 void* malloc(size_t size);
 void free(void* ptr);
 

--- a/src/usr/include/vector.tcc
+++ b/src/usr/include/vector.tcc
@@ -70,7 +70,7 @@ template <typename T>
 typename vector<T>::const_iterator vector<T>::end() const { return this->_data + this->_size; }
 
 template <typename T>
-void vector<T>::resize_capacity(volatile std::size_t capacity) {
+void vector<T>::resize_capacity(std::size_t capacity) {
     // internal; assumes capacity to be power of 2
     // and will also make a copy of array and move _data pointer.
     // assumes size<=current_capacity and size<=new_capacity

--- a/src/usr/include/vector.tcc
+++ b/src/usr/include/vector.tcc
@@ -17,13 +17,18 @@ static std::size_t next_power2(std::size_t size) {
 }
 
 template <typename T>
-vector<T>::vector() : _data(NULL), _size(0) {
+vector<T>::vector() :
+        _data(NULL),
+        _capacity(0),
+        _size(0) {
     resize_capacity(1);
 }
 
 template <typename T>
-vector<T>::vector(std::size_t size, const T &_default): _size(size)  {
-    this->_data = NULL;
+vector<T>::vector(std::size_t size, const T &_default):
+        _data(NULL),
+        _capacity(0),
+        _size(size) {
     resize_capacity(size);
     for(std::size_t i = 0; i < size; i++) {
         this->_data[i] = _default;
@@ -31,7 +36,10 @@ vector<T>::vector(std::size_t size, const T &_default): _size(size)  {
 }
 
 template <typename T>
-vector<T>::vector(const vector<T> &o) : _size(o._size) {
+vector<T>::vector(const vector<T> &o) :
+        _data(NULL),
+        _capacity(0),
+        _size(o._size) {
     resize_capacity(o._capacity);
     std::memcpy(_data, o._data, _capacity*sizeof(T));
 }
@@ -62,14 +70,15 @@ template <typename T>
 typename vector<T>::const_iterator vector<T>::end() const { return this->_data + this->_size; }
 
 template <typename T>
-void vector<T>::resize_capacity(std::size_t capacity) {
+void vector<T>::resize_capacity(volatile std::size_t capacity) {
     // internal; assumes capacity to be power of 2
     // and will also make a copy of array and move _data pointer.
     // assumes size<=current_capacity and size<=new_capacity
-    const std::size_t data_size = capacity*sizeof(T);
+    const std::size_t data_size = std::min(capacity, this->_capacity)*sizeof(T);
     T *_new_data = new T[capacity];
     if (!_new_data) return;  // malloc failed
     std::memcpy(_new_data, this->_data, data_size);
+
     delete[] this->_data;  // should be no-op if _data == NULL
     this->_data = _new_data;
     this->_capacity = capacity;

--- a/src/usr/lib/stdlib.c
+++ b/src/usr/lib/stdlib.c
@@ -156,6 +156,9 @@ int benchmark_get_heap_usage() {
 }
 
 void* malloc(size_t size) {
+    size = ((size + 3) >> 2 ) << 2;
+    size += 4;  // 4 bytes to store size
+
     void* loc = _heap_start + heap_head_offset;
     void* max_loc = get_current_esp()-heap_stack_safety_gap-size;
     if(loc>max_loc) {
@@ -165,11 +168,15 @@ void* malloc(size_t size) {
     }
     heap_head_offset += size;
     benchmark_heap_inuse += size;
-    return loc;
+
+    *((uint32_t*)loc) = size;
+    return (loc+4);
 }
 
 void free(void* ptr) {
     if(ptr == NULL) return;
     // current version of malloc is non-optimal and doesn't
     // do any free operation.
+    size_t size = *((uint32_t*)(ptr-4));
+    benchmark_heap_inuse -= size;
 }

--- a/src/usr/lib/stdlib.c
+++ b/src/usr/lib/stdlib.c
@@ -148,6 +148,13 @@ extern char _heap_start[];  // defined in linker.ld
 static int heap_head_offset = 0;
 static const int heap_stack_safety_gap = 1024; // keep 1 kb free between stack and heap
 
+// benchmarking
+static int benchmark_heap_inuse = 0;
+
+int benchmark_get_heap_usage() {
+    return benchmark_heap_inuse;
+}
+
 void* malloc(size_t size) {
     void* loc = _heap_start + heap_head_offset;
     void* max_loc = get_current_esp()-heap_stack_safety_gap-size;
@@ -157,6 +164,7 @@ void* malloc(size_t size) {
         return NULL;
     }
     heap_head_offset += size;
+    benchmark_heap_inuse += size;
     return loc;
 }
 

--- a/src/usr/local/src/logo.cpp
+++ b/src/usr/local/src/logo.cpp
@@ -20,6 +20,8 @@ void frame_wait() {
     while (counter--);
 }
 
+bool graceful_exit = false;
+
 std::vector<std::string> split(std::string &str) {
     std::vector<std::string> rv;
     std::size_t len = str.length();
@@ -192,7 +194,8 @@ public:
             return 0;
         }
         if (cmd == "exit") {
-            std::exit(0);
+            graceful_exit = true;
+            return 0;
         }
         return 10;
     }
@@ -385,7 +388,7 @@ public:
     Interpreter() : display(console.get_y_offset()) {
     }
     void execute() {
-        while(1) {
+        while(!graceful_exit) {
             console.update_status(display);
             display.draw();
             console.draw();
@@ -408,7 +411,7 @@ void cleanup_graphics() {
     std::graphics::closegraph();
     std::cout << "logo graphics closed" << std::endl;
     std::cout << "heap memory at exit " <<
-        (std::benchmark_get_heap_usage()/1024) << "KB" << std::endl;
+        (std::benchmark_get_heap_usage()) << " bytes" << std::endl;
 }
 
 int show_usage() {
@@ -448,5 +451,6 @@ int main(int argc,char *argv[]) {
     // graphics started
     std::atexit(cleanup_graphics);
     start_logo();
+    std::cout<<" all over \n";
     return 0;
 }

--- a/src/usr/local/src/logo.cpp
+++ b/src/usr/local/src/logo.cpp
@@ -450,6 +450,5 @@ int main(int argc,char *argv[]) {
     // graphics started
     std::atexit(cleanup_graphics);
     start_logo();
-    std::cout<<" all over \n";
     return 0;
 }

--- a/src/usr/local/src/logo.cpp
+++ b/src/usr/local/src/logo.cpp
@@ -20,8 +20,6 @@ void frame_wait() {
     while (counter--);
 }
 
-bool graceful_exit = false;
-
 std::vector<std::string> split(std::string &str) {
     std::vector<std::string> rv;
     std::size_t len = str.length();
@@ -194,8 +192,7 @@ public:
             return 0;
         }
         if (cmd == "exit") {
-            graceful_exit = true;
-            return 0;
+            std::exit(0);
         }
         return 10;
     }
@@ -388,7 +385,7 @@ public:
     Interpreter() : display(console.get_y_offset()) {
     }
     void execute() {
-        while(!graceful_exit) {
+        while(1) {
             console.update_status(display);
             display.draw();
             console.draw();
@@ -410,8 +407,10 @@ void start_logo() {
 void cleanup_graphics() {
     std::graphics::closegraph();
     std::cout << "logo graphics closed" << std::endl;
-    std::cout << "heap memory at exit " <<
+    std::cout << "heap memory usage at exit " <<
         (std::benchmark_get_heap_usage()) << " bytes" << std::endl;
+    std::cout << "heap memory area at exit " <<
+        (std::benchmark_get_heap_area()) << " bytes" << std::endl;
 }
 
 int show_usage() {

--- a/src/usr/local/src/logo.cpp
+++ b/src/usr/local/src/logo.cpp
@@ -407,6 +407,8 @@ void start_logo() {
 void cleanup_graphics() {
     std::graphics::closegraph();
     std::cout << "logo graphics closed" << std::endl;
+    std::cout << "heap memory at exit " <<
+        (std::benchmark_get_heap_usage()/1024) << "KB" << std::endl;
 }
 
 int show_usage() {


### PR DESCRIPTION
Sample:
  - Program 'logo', command:  `repeat 5 [ repeat 45 [ fd 1 rt 8 ] pu fd 15 pd ] ` followed by exit.

Heap Stats: heap memory area
 - 63 KB: Always allocating heap block at the end
 - 17KB: Allocating heap block at the first free block
 - 17KB: Allocating heap block at the first free block while splitting block into two on extra space.
 - 17KB: Above + during malloc merge with free neighbors. 
 - 17KB: Above but instead of selecting the first free block, find the most suitable block in whole heap memory.